### PR TITLE
Configure Vite to output to 'build' directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-dist
-dist-ssr
+build
 *.local
 
 # Editor directories and files

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,8 +5,11 @@ import tailwindcss from "@tailwindcss/vite";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  server : {
-    host : "0.0.0.0",
-    port : 3000
-  },  
+  server: {
+    host: "0.0.0.0",
+    port: 3000,
+  },
+  build: {
+    outDir: "build",
+  },
 });


### PR DESCRIPTION
The Vercel deployment was failing because it expects the build output to be in a directory named 'build', but the Vite default is 'dist'.

This commit updates `vite.config.js` to set the `build.outDir` to 'build' to match Vercel's expected output directory.

Additionally, the `.gitignore` file has been updated to ignore the new `build/` directory.