### PR TITLE
This commit fixes a build error related to Tailwind CSS.

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,4 @@
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
+@import "tailwindcss";
 
 :root {
   --color-primary: #00FFFF;


### PR DESCRIPTION
The previous `@import` statements for Tailwind CSS in `src/index.css` were for an older version and caused the build to fail with the new v4 syntax.

This commit updates `src/index.css` to use the new, simpler `@import "tailwindcss";` syntax, which resolves the build error.